### PR TITLE
add time-grunt

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -12,6 +12,8 @@ var path = require('path');
 module.exports = function (grunt) {
   // load all grunt tasks
   require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  // show elapsed time at the end
+  require('time-grunt')(grunt);
 
   // configurable paths
   var yeomanConfig = {

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -35,6 +35,7 @@
         "connect-livereload": "~0.2.0",
         "grunt-google-cdn": "~0.2.0",
         "grunt-ngmin": "~0.0.2",
-        "grunt-express": "~1.0.0"
+        "grunt-express": "~1.0.0",
+        "time-grunt": "~0.1.1"
     }
 }


### PR DESCRIPTION
[time-grunt](https://github.com/sindresorhus/time-grunt) displays the elapsed execution time of grunt tasks. We're using it in [generator-webapp](https://github.com/yeoman/generator-webapp/blob/master/app/templates/Gruntfile.js#L11-L12).
