### PR TITLE
Fix for static path configuration in development environment

### DIFF
--- a/app/templates/config/environments/development.js
+++ b/app/templates/config/environments/development.js
@@ -23,6 +23,7 @@ module.exports = function (app) {
         });
 
         app.use(app.router);
+        app.use(express.static(path.join(app.directory, 'app')));
         app.use(express.errorHandler());
     });
 };


### PR DESCRIPTION
Fix for static path in config for development environment which resulted in 404 for bower components and other static file.
